### PR TITLE
Fix boot issue by enabling TypeScript 7 support in Next.js builds

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'standalone',
+    experimental: {
+        useTypeScriptCli: true,
+    },
     images: {
         remotePatterns: [
             {


### PR DESCRIPTION
Fix #125

## Summary

Enable Next.js’s experimental TypeScript CLI integration to support TypeScript 7.0.2 during production builds.
This resolves the build failure caused by TypeScript 7 not exposing the compiler API required by Next.js.

## Testing

- Confirmed the production build completes successfully
- Confirmed TypeScript checking runs through the CLI
- Confirmed static page generation and standalone asset copying succeed